### PR TITLE
fix: tolerate dots in some common suffixes

### DIFF
--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -59,19 +59,19 @@ const getFileName = (law: Law.Case | Law.Legislation, doctype: Law.Link[`doctype
 const commonAppends = [
   /\(?pte\.?\)?/,
   /private/,
-  /ltd|limited/,
-  /llp/,
+  /ltd\.?|limited/,
+  /l\.?l\.?p\.?/,
   /sdn|bhd/,
-  /company|co/,
-  /nv|gmbh/,
-  /inc/,
+  /company|co\.?|& co\.?/,
+  /n\.?v\.?|gmbh/,
+  /inc\.?/,
   /\(s\)|\(m\)|\(singapore\)/,
   /(and|&) others|(and|&) (another|other)( (suits?|appeals?|matters?))?|(and|&) \d{1,2} ors|& anor/,
   /\(interim judicial managers appointed\)|\(in liquidation\)|\(under judicial management\)/,
   /, singapore branch/,
 ]
 const commonAppendsPartialRegex = commonAppends.map(append => append.source).join(`|`)
-const commonAppendsRegex = new RegExp(`(\\b|\\s)(${commonAppendsPartialRegex})(\\b|\\s)`, `gi`)
+const commonAppendsRegex = new RegExp(`(\\b|\\s)(${commonAppendsPartialRegex})(\\b|\\s|$)`, `gi`)
 const removeCommonAppends = (caseName: string) => (
   (`${caseName}`)
     .replaceAll(commonAppendsRegex, ` `)

--- a/src/utils/__tests__/Helpers.test.ts
+++ b/src/utils/__tests__/Helpers.test.ts
@@ -5,6 +5,7 @@ const commonAppendsTestCases = [
   [`Kong Chee Chui and others v Soh Ghee Hong`, `Kong Chee Chui v Soh Ghee Hong`],
   [`Fustar Chemicals Ltd v Ong Soo Hwa (liquidator of Fustar Chemicals Pte Ltd)`, `Fustar Chemicals v Ong Soo Hwa (liquidator of Fustar Chemicals)`],
   [`Good Property Land Development Pte Ltd (in liquidation) v Societe-Generale`, `Good Property Land Development v Societe-Generale`],
+  [`G.W.L. Properties Ltd. v. W.R. Grace & Co. of Canada Ltd.`, `G.W.L. Properties v. W.R. Grace of Canada`],
   [`PEX International Pte Ltd v Lim Seng Chye & Anor`, `PEX International v Lim Seng Chye`],
   [`SCK SERIJADI SDN BHD v ARTISON INTERIOR PTE LTD`, `SCK SERIJADI v ARTISON INTERIOR`],
   [`Wong Kwei Cheong v ABN-AMRO Bank NV`, `Wong Kwei Cheong v ABN-AMRO Bank`],


### PR DESCRIPTION
e.g. catch "Ltd." as well as "Ltd" when removing suffixes. Thanks for a great tool!